### PR TITLE
[Feature] Style Additions

### DIFF
--- a/i18n/en/index.ts
+++ b/i18n/en/index.ts
@@ -12,6 +12,17 @@ const en: BaseTranslation = {
       title: 'Display quantity limit',
       description: 'Maximum number of headings that can be displayed. 0 indicates no limit.',
     },
+    indicators: {
+      title: 'Display heading indicators',
+      description: 'Toggle to display heading level indicators'
+    },
+    style: {
+        title: 'Style',
+        description:
+            'Use a simple heading style, or copy in file heading styles',
+        simple: 'Simple',
+        default: 'Default'
+    }
   },
 };
 

--- a/i18n/i18n-types.ts
+++ b/i18n/i18n-types.ts
@@ -43,6 +43,34 @@ type RootTranslation = {
 			 */
 			description: string
 		}
+        indicators: {
+            /**
+             * Display heading indicators
+             */
+            title: string
+            /**
+             * Maximum number of headings that can be displayed. 0 indicates no limit.
+             */
+            description: string
+        }
+        style: {
+            /**
+             * Display of stuck headings
+             */
+            title: string
+            /**
+             * Use a simple heading style, or mimic in page headings
+             */
+            description: string
+            /**
+             * Simple
+             */
+            simple: string
+            /**
+             * Default
+             */
+            default: string
+        }
 	}
 }
 
@@ -75,7 +103,35 @@ export type TranslationFunctions = {
 			 * Maximum number of headings that can be displayed. 0 indicates no limit.
 			 */
 			description: () => LocalizedString
-		}
+		},
+        indicators: {
+            /**
+             * Display heading indicators
+             */
+            title: () => LocalizedString
+            /**
+             * Toggle to display heading level indicators
+             */
+            description: () => LocalizedString
+        }
+        style: {
+            /**
+             * Display of stuck headings
+             */
+            title: () => LocalizedString
+            /**
+             * Use a simple heading style, or mimic in page headings
+             */
+            description: () => LocalizedString
+            /**
+             * Simple
+             */
+            simple: () => LocalizedString
+            /**
+             * Default
+             */
+            default: () => LocalizedString
+        }
 	}
 }
 

--- a/i18n/zh/index.ts
+++ b/i18n/zh/index.ts
@@ -12,6 +12,17 @@ const zh: Translation = {
       title: '显示数量限制',
       description: '最大显示标题数量，0 表示不限制。',
     },
+    indicators: {
+      title: 'NEEDS DOING',
+      description: 'NEEDS DOING'
+    },
+    style: {
+        title: 'NEEDS DOING',
+        description:
+            'NEEDS DOING',
+        simple: 'NEEDS DOING',
+        default: 'NEEDS DOING'
+    }
   },
 };
 

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -200,12 +200,25 @@ export default class StickyHaeddingsPlugin extends Plugin {
       finalHeadings = finalHeadings.slice(-this.settings.max);
     }
     finalHeadings.forEach(heading => {
+      let cls = `sticky-headings-item sticky-headings-level-${heading.level}`
       const headingItem = createDiv({
-        cls: `sticky-headings-item sticky-headings-level-${heading.level}`,
-        text: heading.heading,
-      });
-      const icon = createDiv({ cls: 'sticky-headings-icon' });
-      setIcon(icon, `heading-${heading.level}`);
+          cls,
+          text: heading.heading
+      })
+      if (this.settings.indicators) {
+          const icon = createDiv({ cls: 'sticky-headings-icon' })
+          setIcon(icon, `heading-${heading.level}`)
+          headingItem.prepend(icon)
+      }
+      if (this.settings.style === 'default') {
+          const wrapper = createDiv({
+              cls: `HyperMD-header HyperMD-header-${heading.level}`
+          })
+          wrapper.append(headingItem)
+          headingContainer.append(wrapper)
+      } else {
+          headingContainer.append(headingItem)
+      }
       headingItem.prepend(icon);
       headingContainer.append(headingItem);
       headingItem.addEventListener('click', () => {
@@ -288,5 +301,33 @@ class StickyHeadingsSetting extends PluginSettingTab {
           });
         });
       });
+    new Setting(containerEl)
+      .setName(L.setting.indicators.title())
+      .setDesc(L.setting.indicators.description())
+      .addToggle((toggle) => {
+        toggle
+            .setValue(this.plugin.settings.indicators)
+            .onChange((boolean) => {
+                this.update({
+                    ...this.plugin.settings,
+                    indicators: boolean
+                })
+            })
+      })
+    new Setting(containerEl)
+      .setName(L.setting.style.title())
+      .setDesc(L.setting.style.description())
+      .addDropdown((dropdown) => {
+          dropdown.addOption('simple', L.setting.style.simple())
+          dropdown.addOption('default', L.setting.style.default())
+          dropdown.setValue(this.plugin.settings.style)
+          dropdown.onChange((value) => {
+              this.update({
+                  ...this.plugin.settings,
+                  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                  style: value as 'simple' | 'default'
+              })
+          })
+      })
   }
 }

--- a/src/defaultSetting.ts
+++ b/src/defaultSetting.ts
@@ -1,4 +1,6 @@
 export default {
-  max: 0,
-  mode: 'default',
-} satisfies ISetting;
+    max: 0,
+    mode: 'default',
+    style: 'simple',
+    indicators: true
+} satisfies ISetting

--- a/src/typing.d.ts
+++ b/src/typing.d.ts
@@ -1,4 +1,6 @@
 interface ISetting {
-  max: number;
-  mode: 'default' | 'concise';
+    max: number
+    mode: 'default' | 'concise'
+    indicators: boolean
+    style: 'simple' | 'default'
 }

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,20 @@
+/* @settings
+
+name: Sticky Headings
+id: sticky-headings
+settings:
+    - 
+        id: indent-width
+        title: Indent width
+        description: The indentation width in em units
+        type: variable-number
+        default: 1
+        format: rem
+
+*/
+
 :root {
-	--indent-size: 1em;
+	--indent-width: 1em;
 }
 
 .view-content {
@@ -13,14 +28,15 @@
 	position: absolute;
 	top: 0;
 	width: 100%;
+	padding: 0 var(--file-margins);
 	z-index: 1;
 }
 
 .sticky-headings-container {
 	font-size: 12px;
 	margin: 0 auto;
-	padding: 0 var(--file-margins);
 	background-color: var(--background-primary);
+	max-width: var(--file-line-width);
 }
 
 .sticky-headings-item {
@@ -40,24 +56,24 @@
 	color: var(--link-color);
 }
 
-.sticky-headings-item:nth-of-type(2) {
-	padding-left: var(--indent-size);
+.sticky-headings-item.sticky-headings-level-2 {
+	padding-left: var(--indent-width);
 }
 
-.sticky-headings-item:nth-of-type(3) {
-	padding-left: calc(var(--indent-size) * 2);
+.sticky-headings-item.sticky-headings-level-3 {
+	padding-left: calc(var(--indent-width) * 2);
 }
 
-.sticky-headings-item:nth-of-type(4) {
-	padding-left: calc(var(--indent-size) * 3);
+.sticky-headings-item.sticky-headings-level-4 {
+	padding-left: calc(var(--indent-width) * 3);
 }
 
-.sticky-headings-item:nth-of-type(5) {
-	padding-left: calc(var(--indent-size) * 4);
+.sticky-headings-item.sticky-headings-level-5 {
+	padding-left: calc(var(--indent-width) * 4);
 }
 
-.sticky-headings-item:nth-of-type(6) {
-	padding-left: calc(var(--indent-size) * 5);
+.sticky-headings-item.sticky-headings-level-6 {
+	padding-left: calc(var(--indent-width) * 5);
 }
 
 .sticky-headings-item:last-of-type {

--- a/styles.css
+++ b/styles.css
@@ -1,52 +1,65 @@
+:root {
+	--indent-size: 1em;
+}
+
 .view-content {
-  position: relative;
+	position: relative;
 }
+
 .sticky-headings-root {
-  height: fit-content;
-  /* transition: height 0.05s linear; */
-  overflow: hidden;
-  position: absolute;
-  top: 0;
-  width: 100%;
-  z-index: 1;
+	height: fit-content;
+	/* transition: height 0.05s linear; */
+	overflow: hidden;
+	position: absolute;
+	top: 0;
+	width: 100%;
+	z-index: 1;
 }
+
 .sticky-headings-container {
 	font-size: 12px;
-	max-width: var(--file-line-width);
 	margin: 0 auto;
-	padding-left: 32px;
+	padding: 0 var(--file-margins);
+	background-color: var(--background-primary);
 }
+
 .sticky-headings-item {
 	line-height: 18px;
 	display: flex;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	height: 18px;
+	/* height: 18px; */
 	cursor: var(--cursor-link);
 }
-.sticky-headings-item:last-of-type {
-	padding-bottom: 10px;
-  height: 28px;
-}
+
 .sticky-headings-item svg {
 	width: 16px;
 	height: 16px;
 	margin-right: 8px;
 	color: var(--link-color);
 }
-.sticky-headings-level-2 {
-	padding-left: 1em;
+
+.sticky-headings-item:nth-of-type(2) {
+	padding-left: var(--indent-size);
 }
-.sticky-headings-level-3 {
-	padding-left: 2em;
+
+.sticky-headings-item:nth-of-type(3) {
+	padding-left: calc(var(--indent-size) * 2);
 }
-.sticky-headings-level-4 {
-	padding-left: 3em;
+
+.sticky-headings-item:nth-of-type(4) {
+	padding-left: calc(var(--indent-size) * 3);
 }
-.sticky-headings-level-5 {
-	padding-left: 4em;
+
+.sticky-headings-item:nth-of-type(5) {
+	padding-left: calc(var(--indent-size) * 4);
 }
-.sticky-headings-level-6 {
-	padding-left: 5em;
+
+.sticky-headings-item:nth-of-type(6) {
+	padding-left: calc(var(--indent-size) * 5);
+}
+
+.sticky-headings-item:last-of-type {
+	padding-bottom: 5px;
 }


### PR DESCRIPTION
Added the ability to hide heading level indiciators should one wish, just for simplicity sake, indentation can provide enough information for some.

I also added the option to use simple (current default) heading styles, or to mimic those used within the page. I did this, because I use colours for knowing heading level, and love the look. See below screenshots

- [ ] Need to do zh language updates