### PR TITLE
Use Prettier for Formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -1,47 +1,43 @@
 {
-	"name": "obsidian-sticky-headings",
-	"version": "1.0.6",
-	"description": "Display headings tree during editing and preview to indicate the current position.",
-	"main": "main.js",
-	"scripts": {
-		"dev": "node esbuild.config.mjs",
-		"build": "node esbuild.config.mjs production",
-		"version": "node version-bump.mjs && git add manifest.json versions.json",
-		"typesafe-i18n": "typesafe-i18n",
-		"lint": "eslint ./"
-	},
-	"keywords": [
-		"obsidian",
-		"plugin",
-		"markdown"
-	],
-	"author": "Zhou Hua",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/zhouhua/obsidian-sticky-headings"
-	},
-	"bugs": {
-		"url": "https://github.com/zhouhua/obsidian-sticky-headings/issues"
-	},
-	"license": "MIT",
-	"devDependencies": {
-		"@eslint/js": "^9.6.0",
-		"@stylistic/eslint-plugin": "^2.3.0",
-		"@types/eslint__js": "^8.42.3",
-		"@types/lodash": "^4.17.6",
-		"@types/node": "^20.14.10",
-		"@typescript-eslint/eslint-plugin": "7.16.0",
-		"@typescript-eslint/parser": "7.16.0",
-		"builtin-modules": "3.3.0",
-		"esbuild": "0.23.0",
-		"eslint": "^9.6.0",
-		"obsidian": "latest",
-		"tslib": "2.6.3",
-		"typescript": "5.5.3",
-		"typescript-eslint": "^7.16.0"
-	},
-	"dependencies": {
-		"lodash": "^4.17.21",
-		"typesafe-i18n": "^5.26.2"
-	}
+  "name": "obsidian-sticky-headings",
+  "version": "1.0.6",
+  "description": "Display headings tree during editing and preview to indicate the current position.",
+  "main": "main.js",
+  "scripts": {
+    "dev": "node esbuild.config.mjs",
+    "build": "node esbuild.config.mjs production",
+    "version": "node version-bump.mjs && git add manifest.json versions.json",
+    "typesafe-i18n": "typesafe-i18n",
+    "lint": "eslint ./"
+  },
+  "keywords": [
+    "obsidian",
+    "plugin",
+    "markdown"
+  ],
+  "author": "Zhou Hua",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zhouhua/obsidian-sticky-headings"
+  },
+  "bugs": {
+    "url": "https://github.com/zhouhua/obsidian-sticky-headings/issues"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@eslint/js": "^9.6.0",
+    "@types/eslint__js": "^8.42.3",
+    "@types/lodash": "^4.17.6",
+    "@types/node": "^20.14.10",
+    "builtin-modules": "3.3.0",
+    "esbuild": "0.23.0",
+    "eslint": "^9.6.0",
+    "obsidian": "latest",
+    "tslib": "2.6.3",
+    "typescript": "5.5.3"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21",
+    "typesafe-i18n": "^5.26.2"
+  }
 }

--- a/src/L.ts
+++ b/src/L.ts
@@ -15,8 +15,7 @@ declare global {
 let locale: Locales = 'en';
 try {
   locale = (window.i18next.language || '').startsWith('zh') ? 'zh' : 'en';
-}
-catch (e) {
+} catch (e) {
   /* empty */
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,35 +21,39 @@ export function parseMarkdown(markdown: string, app: App): Promise<string> {
     return Promise.resolve(markdown); // Return the original markdown if rendering is not possible
   }
 
-  return MarkdownRenderer.render(app, markdown, div, '', activeView).then(() => {
-    return div.innerText;
-  });
+  return MarkdownRenderer.render(app, markdown, div, '', activeView).then(
+    () => {
+      return div.innerText;
+    }
+  );
 }
 
 export function trivial(
   subHeadings: HeadingCache[],
   result: HeadingCache[],
-  mode: 'default' | 'concise',
+  mode: 'default' | 'concise'
 ) {
   if (!subHeadings.length) {
     return result;
   }
   const topLevel = subHeadings.reduce(
     (res, cur) => Math.min(res, cur.level),
-    6,
+    6
   );
-  const indexesOfTopLevel = subHeadings.reduce<number[]>((indexes, cur, index) => {
-    if (cur.level === topLevel) {
-      indexes.push(index);
-    }
-    return indexes;
-  }, []);
+  const indexesOfTopLevel = subHeadings.reduce<number[]>(
+    (indexes, cur, index) => {
+      if (cur.level === topLevel) {
+        indexes.push(index);
+      }
+      return indexes;
+    },
+    []
+  );
   if (mode === 'concise') {
     if (indexesOfTopLevel.length >= 1) {
       result.push(subHeadings[indexesOfTopLevel[indexesOfTopLevel.length - 1]]);
     }
-  }
-  else {
+  } else {
     for (const index of indexesOfTopLevel) {
       result.push(subHeadings[index]);
     }
@@ -57,11 +61,15 @@ export function trivial(
   trivial(
     subHeadings.slice(indexesOfTopLevel[indexesOfTopLevel.length - 1] + 1),
     result,
-    mode,
+    mode
   );
 }
 
-function findLastFromindex<T = unknown>(list: T[], lastIndex: number, check: (item: T) => boolean): number {
+function findLastFromindex<T = unknown>(
+  list: T[],
+  lastIndex: number,
+  check: (item: T) => boolean
+): number {
   let index = -1;
   for (let i = lastIndex; i >= 0; i--) {
     if (check(list[i])) {
@@ -79,19 +87,26 @@ export function calcIndentLevels(headings: HeadingCache[]): number[] {
   }
   const topLevelIndex = headings.reduce<number>(
     (res, cur, i) => (cur.level < headings[res].level ? i : res),
-    0,
+    0
   );
-  result.push(...calcIndentLevels(headings.slice(0, topLevelIndex)).map(level => level + 1));
+  result.push(
+    ...calcIndentLevels(headings.slice(0, topLevelIndex)).map(
+      (level) => level + 1
+    )
+  );
   headings.slice(topLevelIndex).forEach((heading, i, list) => {
     if (i === 0) {
       result.push(0);
       return;
     }
-    const parentIndex = findLastFromindex(list, i - 1, item => item.level < heading.level);
+    const parentIndex = findLastFromindex(
+      list,
+      i - 1,
+      (item) => item.level < heading.level
+    );
     if (parentIndex === -1) {
       result.push(0);
-    }
-    else {
+    } else {
       result.push(result[parentIndex + topLevelIndex] + 1);
     }
   });


### PR DESCRIPTION
Uses [Prettier](https://prettier.io/) for code formatting as apposed to the stylistic approach. 

This simply boils down to portability, it's far easier to have developers install prettier and maintain a simple, consistent approach across workspaces. 

Feel free to set your own terms within `.prettierrc`, I'm happy to use single quotes for example if this is what you'd prefer. 

This is worth merging before we both branch off for our singular pieces of work as a consistent formatting approach will benefit us during any merge conflicts 👍