### PR TITLE
Add Svelte components separately for preview mode and edit mode

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,7 +134,7 @@ export default tseslint.config(
       '@typescript-eslint/member-ordering': ['warn'],
       '@typescript-eslint/no-array-delete': 'error',
       '@typescript-eslint/no-confusing-non-null-assertion': 'error',
-      '@typescript-eslint/no-confusing-void-expression': 'error',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
       '@typescript-eslint/no-dupe-class-members': 'error',
       '@typescript-eslint/no-dynamic-delete': 'off',
       '@typescript-eslint/no-empty-interface': 'error',

--- a/src/stickyHeader.ts
+++ b/src/stickyHeader.ts
@@ -3,39 +3,52 @@ import type { MarkdownView } from 'obsidian';
 import type { Heading, ISetting } from './types';
 
 export default class StickyHeaderComponent {
-  stickyHeaderComponent!: StickyHeader;
+  stickyHeaderComponents!: [StickyHeader, StickyHeader];
 
   constructor(view: MarkdownView, settings: ISetting) {
     this.addStickyHeader(view, settings);
   }
 
   addStickyHeader(view: MarkdownView, settings: ISetting) {
-    const { contentEl } = view;
-    this.stickyHeaderComponent = new StickyHeader({
-      target: contentEl,
-      props: {
-        headings: [],
-        editMode: false,
-        view,
-        getExpectedHeadings: () => [],
-        settings,
-      },
-    });
+    const previewContentEl = view.previewMode.containerEl;
+    const sourceContentEl = view.editMode.editorEl;
+    this.stickyHeaderComponents = [
+      new StickyHeader({
+        target: previewContentEl,
+        props: {
+          headings: [],
+          editMode: false,
+          view,
+          getExpectedHeadings: () => [],
+          settings,
+        },
+      }),
+      new StickyHeader({
+        target: sourceContentEl,
+        props: {
+          headings: [],
+          editMode: false,
+          view,
+          getExpectedHeadings: () => [],
+          settings,
+        },
+      }),
+    ];
   }
 
   removeStickyHeader() {
-    this.stickyHeaderComponent.$destroy();
+    this.stickyHeaderComponents.forEach(conponent => conponent.$destroy());
   }
 
   updateHeadings(headings: Heading[], getExpectedHeadings: (index: number) => Heading[]) {
-    this.stickyHeaderComponent.$set({ headings, getExpectedHeadings });
+    this.stickyHeaderComponents.forEach(conponent => conponent.$set({ headings, getExpectedHeadings }));
   }
 
   updateEditMode(editMode: boolean) {
-    this.stickyHeaderComponent.$set({ editMode });
+    this.stickyHeaderComponents.forEach(conponent => conponent.$set({ editMode }));
   }
 
   updateSettings(settings: ISetting) {
-    this.stickyHeaderComponent.$set({ settings });
+    this.stickyHeaderComponents.forEach(conponent => conponent.$set({ settings }));
   }
 }


### PR DESCRIPTION
@itsonlyjames  #29 is an issue that needs to be resolved. Your idea was to use a single StickyHeader component to satisfy both preview mode and source mode. However, based on this implementation, I tried various ways to solve the problem mentioned in #29, where the search box gets covered, but none were successful. So, I modified your implementation to add separate StickyHeader components for preview mode and source mode.