### PR TITLE
auto show filename

### DIFF
--- a/i18n/en/index.ts
+++ b/i18n/en/index.ts
@@ -14,7 +14,7 @@ const en: BaseTranslation = {
       description: 'Maximum number of headings that can be displayed. 0 indicates no limit.',
     },
     scrollBehaviour: {
-      title: 'Scroll Behaviour',
+      title: 'Scroll behaviour',
       description: 'Choose between instant or smooth scrolling behaviour',
       smooth: 'Smooth',
       instant: 'Instant',
@@ -25,6 +25,11 @@ const en: BaseTranslation = {
     indicators: {
       title: 'Display heading indicators',
       description: 'Toggle to display heading level indicators',
+    },
+    autoShowFileName: {
+      title: 'Auto show file name',
+      description:
+        'When enabled, if the first heading in the note is not the unique highest-level title, an additional title with the filename as the highest-level title will be added to achieve a better document outline.',
     },
   },
 };

--- a/i18n/i18n-types.ts
+++ b/i18n/i18n-types.ts
@@ -45,7 +45,7 @@ type RootTranslation = {
 		}
 		scrollBehaviour: {
 			/**
-			 * S​c​r​o​l​l​ ​B​e​h​a​v​i​o​u​r
+			 * S​c​r​o​l​l​ ​b​e​h​a​v​i​o​u​r
 			 */
 			title: string
 			/**
@@ -74,6 +74,16 @@ type RootTranslation = {
 			title: string
 			/**
 			 * T​o​g​g​l​e​ ​t​o​ ​d​i​s​p​l​a​y​ ​h​e​a​d​i​n​g​ ​l​e​v​e​l​ ​i​n​d​i​c​a​t​o​r​s
+			 */
+			description: string
+		}
+		autoShowFileName: {
+			/**
+			 * A​u​t​o​ ​s​h​o​w​ ​f​i​l​e​ ​n​a​m​e
+			 */
+			title: string
+			/**
+			 * W​h​e​n​ ​e​n​a​b​l​e​d​,​ ​i​f​ ​t​h​e​ ​f​i​r​s​t​ ​h​e​a​d​i​n​g​ ​i​n​ ​t​h​e​ ​n​o​t​e​ ​i​s​ ​n​o​t​ ​t​h​e​ ​u​n​i​q​u​e​ ​h​i​g​h​e​s​t​-​l​e​v​e​l​ ​t​i​t​l​e​,​ ​a​n​ ​a​d​d​i​t​i​o​n​a​l​ ​t​i​t​l​e​ ​w​i​t​h​ ​t​h​e​ ​f​i​l​e​n​a​m​e​ ​a​s​ ​t​h​e​ ​h​i​g​h​e​s​t​-​l​e​v​e​l​ ​t​i​t​l​e​ ​w​i​l​l​ ​b​e​ ​a​d​d​e​d​ ​t​o​ ​a​c​h​i​e​v​e​ ​a​ ​b​e​t​t​e​r​ ​d​o​c​u​m​e​n​t​ ​o​u​t​l​i​n​e​.
 			 */
 			description: string
 		}
@@ -112,7 +122,7 @@ export type TranslationFunctions = {
 		}
 		scrollBehaviour: {
 			/**
-			 * Scroll Behaviour
+			 * Scroll behaviour
 			 */
 			title: () => LocalizedString
 			/**
@@ -141,6 +151,16 @@ export type TranslationFunctions = {
 			title: () => LocalizedString
 			/**
 			 * Toggle to display heading level indicators
+			 */
+			description: () => LocalizedString
+		}
+		autoShowFileName: {
+			/**
+			 * Auto show file name
+			 */
+			title: () => LocalizedString
+			/**
+			 * When enabled, if the first heading in the note is not the unique highest-level title, an additional title with the filename as the highest-level title will be added to achieve a better document outline.
 			 */
 			description: () => LocalizedString
 		}

--- a/i18n/zh/index.ts
+++ b/i18n/zh/index.ts
@@ -25,6 +25,11 @@ const zh: Translation = {
       title: '显示标题图标',
       description: '是否展示标题级别图标',
     },
+    autoShowFileName: {
+      title: '自动显示文件名',
+      description:
+        '开启后，如果笔记的第一个标题不是唯一最高级标题，则会额外添加一个以文件名为标题的最高级标题，以达到更好的文档大纲效果。',
+    },
   },
 };
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -9,6 +9,7 @@ import {
   getScroller,
   isEditSourceMode,
   isMarkdownFile,
+  needShowFileName,
   parseMarkdown,
 } from './utils/obsidian';
 
@@ -163,7 +164,9 @@ export default class StickyHeadingsPlugin extends Plugin {
           ...heading,
           indentLevel: indentList[i] || 0,
         })),
-        makeExpectedHeadings(headings, this.settings.max, this.settings.mode)
+        makeExpectedHeadings(headings, this.settings.max, this.settings.mode),
+        this.settings.autoShowFileName && needShowFileName(item.file, this.app),
+        item.view
       );
     }
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export const defaultSettings = {
   scrollBehaviour: 'smooth',
   theme: 'flat',
   showIcon: true,
+  autoShowFileName: true,
 } satisfies ISetting;
 
 export default class StickyHeadingsSetting extends PluginSettingTab {
@@ -92,6 +93,18 @@ export default class StickyHeadingsSetting extends PluginSettingTab {
           this.update({
             ...this.plugin.settings,
             showIcon: value,
+          });
+        });
+      });
+    new Setting(containerEl)
+      .setName(L.setting.autoShowFileName.title())
+      .setDesc(L.setting.autoShowFileName.description())
+      .addToggle(toggle => {
+        toggle.setValue(this.plugin.settings.autoShowFileName);
+        toggle.onChange(value => {
+          this.update({
+            ...this.plugin.settings,
+            autoShowFileName: value,
           });
         });
       });

--- a/src/stickyHeader.ts
+++ b/src/stickyHeader.ts
@@ -21,6 +21,7 @@ export default class StickyHeaderComponent {
           view,
           getExpectedHeadings: () => [],
           settings,
+          showFileName: false,
         },
       }),
       new StickyHeader({
@@ -31,6 +32,7 @@ export default class StickyHeaderComponent {
           view,
           getExpectedHeadings: () => [],
           settings,
+          showFileName: false,
         },
       }),
     ];
@@ -40,8 +42,15 @@ export default class StickyHeaderComponent {
     this.stickyHeaderComponents.forEach(conponent => conponent.$destroy());
   }
 
-  updateHeadings(headings: Heading[], getExpectedHeadings: (index: number) => Heading[]) {
-    this.stickyHeaderComponents.forEach(conponent => conponent.$set({ headings, getExpectedHeadings }));
+  updateHeadings(
+    headings: Heading[],
+    getExpectedHeadings: (index: number) => Heading[],
+    showFileName: boolean,
+    view: MarkdownView
+  ) {
+    this.stickyHeaderComponents.forEach(conponent =>
+      conponent.$set({ headings, getExpectedHeadings, showFileName, view })
+    );
   }
 
   updateEditMode(editMode: boolean) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,6 +7,7 @@ export interface ISetting {
   theme: string;
   scrollBehaviour: ScrollBehavior;
   showIcon: boolean;
+  autoShowFileName: boolean;
 }
 
 export interface FileResolveEntry {

--- a/src/utils/obsidian.ts
+++ b/src/utils/obsidian.ts
@@ -37,3 +37,17 @@ export const getScroller = (view: MarkdownView) =>
 
 export const getContainerEl = (el: HTMLElement | Element) =>
   el.closest('.markdown-reading-view, .markdown-source-view')?.querySelector('.sticky-headings-root');
+
+export function needShowFileName(file: TFile, app: App): boolean {
+  const headings = getHeadings(file, app);
+  if (headings.length === 0) {
+    return false;
+  }
+  const firstLevel = headings[0].level;
+  for (let i = 1; i < headings.length; i++) {
+    if (headings[i].level <= firstLevel) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
In #6, I mentioned the idea of 'h0'. This PR implements that idea. Currently, the definition of h0 is quite simple and doesn't take into account the user's inline-title settings. It only checks whether the first heading in the note is the unique highest-level heading in the entire note. If it isn't, then the filename is used as h0. A setting switch is provided to turn this feature off.