### PR TITLE
Quiet logging

### DIFF
--- a/src/ui/StickyHeader.svelte
+++ b/src/ui/StickyHeader.svelte
@@ -19,11 +19,11 @@
   const filename = view.getFile()?.basename;
 
   onMount(() => {
-    console.log('mounted svelte component');
+    console.debug('mounted svelte component');
   });
 
   onDestroy(() => {
-    console.log('destroyed');
+    console.debug('destroyed');
   });
 
   const calculateExpectedHeight = async (index: number) => {


### PR DESCRIPTION
From the [plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+unnecessary+logging+to+console):

> Please avoid unnecessary logging.
> In it's default configuration, the developer console should only show error messages, debug messages should not be shown.